### PR TITLE
Changed the function named calc_speed_cost

### DIFF
--- a/src/dwa_planner.cpp
+++ b/src/dwa_planner.cpp
@@ -246,7 +246,7 @@ float DWAPlanner::calc_to_goal_cost(const std::vector<State>& traj, const Eigen:
 
 float DWAPlanner::calc_speed_cost(const std::vector<State>& traj, const float target_velocity)
 {
-    float cost = fabs(target_velocity - traj[traj.size()-1].velocity);
+    float cost = fabs(target_velocity - fabs(traj[traj.size()-1].velocity));
     return cost;
 }
 


### PR DESCRIPTION
When I allowed robot to move backwards (which means set MIN_VELOCITY
as minus value) this function costs illegally high to minus velocity. So
I changed this function to consider the cost with abusolute value of
velocity.